### PR TITLE
Remove dependency on AWS SES

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,10 @@
 
 ### Mailsploit Server
 
-*Note*: You will need an Amazon SES account with a verified domain in order to use the tool. Also, the web server can only run at 88 miles per hour.
-
 #### How to install
 
 1. Clone the repository
-2. Edit `originalFrom` in `src/main/Config.ts` with your verified SES email address.
+2. Edit `originalFrom` in `src/main/Config.ts` with your email address.
 3. Run the following commands in the terminal:
 ```
 yarn install && yarn dist # Require yarn
@@ -15,9 +13,15 @@ yarn install && yarn dist # Require yarn
 
 #### How to launch the web server
 
-1. Run the following command in the terminal:
+1. Run the following commands in the terminal:
 ```
-SES_USERNAME=[Amazon SES Username] SES_PASSWORD=[Amazon SES Password] node dist/commonjs/index.js
+# First configure the environment
+export MAILSPLOIT_HOST=[SMTP Server Hostname]
+export MAILSPLOIT_PORT=[SMTP Server Port (default 465)]
+export MAILSPLOIT_USERNAME=[SMTP Server Username]
+export MAILSPLOIT_PASSWORD=[SMTP Server Password]
+export MAILSPLOIT_IGNORE_TLS=[Boolean - Ignore self signed certificates]
+npm run build && npm start
 ```
 2. That's it. The server will run on localhost:8081
 

--- a/src/main/Dispatcher.ts
+++ b/src/main/Dispatcher.ts
@@ -10,6 +10,12 @@ import * as SMTPTransport from 'nodemailer/lib/smtp-transport';
 import {PayloadDirectory, PayloadDirectoryCount} from './Payloads';
 import {Config} from './Config';
 
+const username = process.env.MAILSPLOIT_USERNAME;
+const password = process.env.MAILSPLOIT_PASSWORD;
+const host = process.env.MAILSPLOIT_HOST || 'email-smtp.eu-west-1.amazonaws.com';
+const port = Number(process.env.MAILSPLOIT_PORT || 465);
+const ignoreTls = process.env.MAILSPLOIT_IGNORE_TLS;
+
 export class Dispatcher {
   private transporter;
 
@@ -19,14 +25,15 @@ export class Dispatcher {
     );
   }
 
-  constructor(private username: string, private password: string) {
+  constructor() {
     this.transporter = nodeMailer.createTransport({
-      host: 'email-smtp.eu-west-1.amazonaws.com',
-      port: 465,
-      secure: true,
+      host,
+      port,
+      tls: { rejectUnauthorized: !ignoreTls },
+      secure: !(port === 25 || port === 587),
       auth: {
-        user: this.username,
-        pass: this.password,
+        user: username,
+        pass: password,
       },
       // Pool
       pool: true,

--- a/src/main/Routes/Process.ts
+++ b/src/main/Routes/Process.ts
@@ -7,7 +7,7 @@ import * as express from 'express';
 import * as bodyParser from 'body-parser';
 import {Dispatcher} from '../Dispatcher';
 
-const dispatcher = new Dispatcher(<string>process.env.SES_USERNAME, <string>process.env.SES_PASSWORD);
+const dispatcher = new Dispatcher();
 
 const router: express.Router = express.Router();
 const handler: express.Handler = async (req, res): Promise<express.Response> => {


### PR DESCRIPTION
This demo is awesome, but I wanted to test this from my own mail servers instead of from AWS SES.

This extends configuration to work with any SMTP server including AWS SES. This might help other people who don't have AWS SES.